### PR TITLE
[bug fix]タブとして開く場合の時、2ch linkジャンプを正確にさせる

### DIFF
--- a/main-ui.js
+++ b/main-ui.js
@@ -1426,7 +1426,7 @@ $(function() {
       util2ch.is2chBBSURL(href)) {
       e.keyCode = 13; // set Enter key to the event
       txt_url.val(href).trigger("keydown", e);
-      return;
+      return false;
     }
     if (!href) return false; // if res's anchor link, return to exit.
     // check whether image link or others


### PR DESCRIPTION
Issue:
Small bug in tab mode.
Instead of jumping to the designated thread inside the app when clicking on 2ch forum link in content, It opened the link directly.

Fix:
I changed the function to return false to prevent the browser opening the link directly.

日本語合ってるかな@_@ 
